### PR TITLE
Fix typo in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,4 +11,4 @@ Panel allows our users to manage their account information and gives them access
 Media allows our members to upload photos and image assets so that they can be downloaded and used later without having to find out who has the logo SVG ever again. It is custom-made and uses [Twig](http://twig.sensiolabs.org) for templating. It can be found in `cif-media/`.
 
 ### CDN
-The CDN is a centralized place for our stylesheets, JavaScript, and other related assets. Our stylesheet is written in [Sass](http://sass-lang.com) to make it more manageable than a CSS file. The CDN is intended to be as optimized as possible to serve out our assets quickly. Its file our located in `cdn/`.
+The CDN is a centralized place for our stylesheets, JavaScript, and other related assets. Our stylesheet is written in [Sass](http://sass-lang.com) to make it more manageable than a CSS file. The CDN is intended to be as optimized as possible to serve out our assets quickly. Its files are located in `cdn/`.


### PR DESCRIPTION
I fixed a typo in the README, but I also couldn't find the referenced `cdn/` folder, so I'm not sure if this section is outdated?

It also doesn't mention _which_ CDN CIF uses...